### PR TITLE
rewrite system_call to handle stdout/stderr IO better

### DIFF
--- a/rtc.py
+++ b/rtc.py
@@ -70,12 +70,11 @@ def delete_dim_files(name):
     os.unlink(name + ".dim")
     shutil.rmtree(name + ".data")
 
+
 def system_call(params):
-    try:
-        output = subprocess.check_output(params)
-    except subprocess.CalledProcessError as e:
-        print("ERROR: " + e.returncode + ", output:\n" + e.output)
-        exit(1)
+    return_code = subprocess.call(params)
+    if return_code:
+        exit(return_code)
     return None
 
 


### PR DESCRIPTION
check_output() was redirecting STDOUT away from the terminal (although STDERR was still showing up)

call() sends both STDOUT and STDERR to the terminal as desired, and lets us check the return code via a normal `if` instead of having to rely on exceptions